### PR TITLE
Add NPM global install support

### DIFF
--- a/bin/harmonyhub-cli
+++ b/bin/harmonyhub-cli
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('../harmonyHubCli.js');

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.1.0",
   "description": "A CLI for controlling harmony remote hub",
   "main": "harmonyHubCLI.js",
+  "bin": {
+    "harmonyhub-cli": "./bin/harmonyhub-cli"
+  },
   "scripts": {
     "start": "node harmonyHubCLI.js"
   },


### PR DESCRIPTION
Once merged, you can run `npm publish` to submit the project to the npm repository. This will allow users to easily install the script by using `npm install -g harmonyhub-cli`, and then execute commands from any path by using the `harmonyhub-cli` command.
